### PR TITLE
Show icon to present protected values

### DIFF
--- a/authpass/lib/ui/screens/entry_details.dart
+++ b/authpass/lib/ui/screens/entry_details.dart
@@ -1308,6 +1308,13 @@ class _EntryFieldState extends State<EntryField>
           });
         });
       },
+      onShowPressed: () {
+        FullScreenHud.show(context, (context) {
+          return FullScreenHud(
+            value: _valueCurrent ?? ''
+          );
+        });
+      },
       fieldKey: widget.fieldKey,
       commonField: widget.commonField,
     );
@@ -1538,6 +1545,7 @@ class ObscuredEntryFieldEditor extends StatelessWidget {
   const ObscuredEntryFieldEditor({
     Key key,
     @required this.onPressed,
+    @required this.onShowPressed,
     @required this.commonField,
     @required this.fieldKey,
   }) : super(key: key);
@@ -1545,6 +1553,7 @@ class ObscuredEntryFieldEditor extends StatelessWidget {
   final CommonField commonField;
   final KdbxKey fieldKey;
   final VoidCallback onPressed;
+  final VoidCallback onShowPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -1590,16 +1599,10 @@ class ObscuredEntryFieldEditor extends StatelessWidget {
           ],
         ), 
         IconButton(
-          icon: Icon(FontAwesomeIcons.eye),
+          icon: const Icon(FontAwesomeIcons.eye),
           color: ThemeUtil.iconColor(Theme.of(context), null),
           tooltip: 'Show protected field',
-          onPressed: () {
-            FullScreenHud.show(context, (context) {
-              return FullScreenHud(
-                value: fieldKey.key,
-              );
-            });
-          },
+          onPressed: onShowPressed,
         ),
       ],
     );

--- a/authpass/lib/ui/screens/entry_details.dart
+++ b/authpass/lib/ui/screens/entry_details.dart
@@ -1309,11 +1309,7 @@ class _EntryFieldState extends State<EntryField>
         });
       },
       onShowPressed: () {
-        FullScreenHud.show(context, (context) {
-          return FullScreenHud(
-            value: _valueCurrent ?? ''
-          );
-        });
+        _handleMenuEntrySelected(EntryAction.show);
       },
       fieldKey: widget.fieldKey,
       commonField: widget.commonField,

--- a/authpass/lib/ui/screens/entry_details.dart
+++ b/authpass/lib/ui/screens/entry_details.dart
@@ -48,6 +48,7 @@ import 'package:otp/otp.dart';
 import 'package:path/path.dart' as path;
 import 'package:provider/provider.dart';
 import 'package:tuple/tuple.dart';
+import 'package:authpass/utils/theme_utils.dart';
 
 final _logger = Logger('entry_details');
 
@@ -1548,40 +1549,57 @@ class ObscuredEntryFieldEditor extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Stack(
+      alignment: Alignment.centerRight,
       children: [
-        InputDecorator(
-          decoration: InputDecoration(
-            prefixIcon:
-                commonField?.icon == null ? null : Icon(commonField.icon),
-            labelText: commonField?.displayName ?? fieldKey.key,
-            filled: true,
-          ),
-          child: const Text(
-            '*****************',
-            style: TextStyle(color: Colors.white),
-          ),
-        ),
-        Positioned.fill(
-          child: ClipRect(
-            child: BackdropFilter(
-              filter: ui.ImageFilter.blur(
-                sigmaX: 0.5,
-                sigmaY: 0.5,
+        Stack(
+          children: [
+            InputDecorator(
+              decoration: InputDecoration(
+                prefixIcon:
+                    commonField?.icon == null ? null : Icon(commonField.icon),
+                labelText: commonField?.displayName ?? fieldKey.key,
+                filled: true,
               ),
-              child: LinkButton(
-                child: Container(
-                  alignment: Alignment.bottomCenter,
-                  padding: const EdgeInsets.only(left: 12.0 + 24.0, bottom: 16),
-                  child: const Text(
-                    'Protected field. Click to reveal.',
-                    style: TextStyle(
-                        shadows: [Shadow(color: Colors.white, blurRadius: 5)]),
-                  ),
-                ),
-                onPressed: onPressed,
+              child: const Text(
+                '*****************',
+                style: TextStyle(color: Colors.white),
               ),
             ),
-          ),
+            Positioned.fill(
+              child: ClipRect(
+                child: BackdropFilter(
+                  filter: ui.ImageFilter.blur(
+                    sigmaX: 0.5,
+                    sigmaY: 0.5,
+                  ),
+                  child: LinkButton(
+                    child: Container(
+                      alignment: Alignment.bottomCenter,
+                      padding: const EdgeInsets.only(left: 12.0 + 24.0, bottom: 16, right: 12),
+                      child: const Text(
+                        'Protected field. Click to reveal.',
+                        style: TextStyle(
+                            shadows: [Shadow(color: Colors.white, blurRadius: 5)]),
+                      ),
+                    ),
+                    onPressed: onPressed,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ), 
+        IconButton(
+          icon: Icon(FontAwesomeIcons.eye),
+          color: ThemeUtil.iconColor(Theme.of(context), null),
+          tooltip: 'Show protected field',
+          onPressed: () {
+            FullScreenHud.show(context, (context) {
+              return FullScreenHud(
+                value: fieldKey.key,
+              );
+            });
+          },
         ),
       ],
     );


### PR DESCRIPTION
This PR adds a small eye-icon on protected fields which triggers the "present" feature.
This could be a small workaround for only showing passwords, where the user doesn't need to "search" for the present option in the overflow menu. 
Maybe this could also be a temporary solution for the issues #107, #109 and #148.