### PR TITLE
Do not try to re-open last password file with biometrics when file is closed

### DIFF
--- a/authpass/lib/bloc/kdbx_bloc.dart
+++ b/authpass/lib/bloc/kdbx_bloc.dart
@@ -506,15 +506,16 @@ class KdbxBloc {
     for (final file in _openedFiles.value.values) {
       file.kdbxFile.dispose();
     }
-    _openedFiles.value = OpenedKdbxFiles({});
     if (clearQuickUnlock) {
       if (_openedFilesQuickUnlock.isNotEmpty) {
         // clear all quick unlock data.
         _openedFilesQuickUnlock.clear();
         await quickUnlockStorage.updateQuickUnlockFile({});
       }
+      _openedFiles.value = OpenedKdbxFiles({});
       analytics.events.trackCloseAllFiles(count: _openedFiles.value?.length);
     } else {
+      _openedFiles.value = OpenedKdbxFiles({});
       analytics.events.trackLockAllFiles(count: _openedFiles.value?.length);
     }
   }


### PR DESCRIPTION
After closing a password file the biometric prompt is shown and the last password file is still opened afterwards (mentioned in issue #153).
With this change the biometric prompt is shown (apparently needed to delete from the biometric storage) and afterwards the main screen is shown.
The biometric prompt for opening of the last password file is no longer shown.

When the file is only unlocked and not closed the biometric prompt for opening is still shown.