### PR TITLE
Support for searching extra URL fields

### DIFF
--- a/authpass/lib/ui/screens/password_list.dart
+++ b/authpass/lib/ui/screens/password_list.dart
@@ -251,7 +251,12 @@ class PasswordListFilterIsolateRunner {
               .isEmpty &&
           entry.groupNames
               .where((string) => string.toLowerCase().contains(term))
-              .isEmpty) {
+              .isEmpty &&
+          // check for extra URL fields as well
+          entry.entry.stringEntries
+              .where((field) =>
+                  field.key.key.startsWith('KP2A_URL') && field.value.toString().contains(term)
+              ).isEmpty) {
         return false;
       }
     }


### PR DESCRIPTION
There are Keepass clients like KeepassXC and Keepas2Android that have added a way to assign multiple URLs to the same entry by using some fields named KP2A_URL, KP2A_URL_1, KP2A_URL_2, etc.
See https://github.com/keepassxreboot/keepassxc/pull/3558

This is a simple  change to include those fields in the results for the search so that it's possible for them to show up.