### PR TITLE
Add CONTRIBUTORS.md content to about dialog

### DIFF
--- a/authpass/CHANGELOG.md
+++ b/authpass/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.8.2 - unreleased
+
+* Add `CONTRIBUTORS.md` to about dialog. #237 (@ATofighi)
+
 # 1.8.1 - 2021-07-13
 
 * Fixed bug when reading cloud email.

--- a/authpass/assets/CONTRIBUTORS.md
+++ b/authpass/assets/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+../../CONTRIBUTORS.md

--- a/authpass/lib/ui/screens/about.dart
+++ b/authpass/lib/ui/screens/about.dart
@@ -4,10 +4,10 @@ import 'package:authpass/env/_base.dart';
 import 'package:authpass/utils/dialog_utils.dart';
 import 'package:authpass/utils/logging_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
-import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
 import 'package:string_literal_finder_annotations/string_literal_finder_annotations.dart';
 
@@ -50,14 +50,26 @@ class AuthPassAboutDialog extends StatelessWidget {
             applicationLegalese: '© by Herbert Poul, 2019-2021', // NON-NLS
             children: <Widget>[
               const SizedBox(height: 32),
+              UrlLink(
+                caption: loc.aboutLinkFeedback,
+                url: 'mailto:hello@authpass.app',
+              ),
+              UrlLink(
+                caption: loc.aboutLinkVisitWebsite,
+                url: 'https://authpass.app/',
+              ),
+              UrlLink(
+                caption: loc.aboutLinkGitHub,
+                url: 'https://github.com/authpass/authpass/',
+              ),
+              const SizedBox(height: 32),
               FutureBuilder(
-                  future: http.read(Uri.parse(
-                      'https://raw.githubusercontent.com/authpass/authpass/master/CONTRIBUTORS.md')),
+                  future: rootBundle.loadString('assets/CONTRIBUTORS.md'),
                   builder:
                       (BuildContext context, AsyncSnapshot<String> snapshot) {
                     if (snapshot.hasData) {
                       return MarkdownBody(
-                        data: snapshot.data!,
+                        data: snapshot.requireData,
                         imageBuilder: (uri, title, alt) {
                           return const SizedBox.shrink(); // Remove images
                         },
@@ -73,19 +85,6 @@ class AuthPassAboutDialog extends StatelessWidget {
                       child: CircularProgressIndicator(),
                     );
                   }),
-              const SizedBox(height: 32),
-              UrlLink(
-                caption: loc.aboutLinkFeedback,
-                url: 'mailto:hello@authpass.app',
-              ),
-              UrlLink(
-                caption: loc.aboutLinkVisitWebsite,
-                url: 'https://authpass.app/',
-              ),
-              UrlLink(
-                caption: loc.aboutLinkGitHub,
-                url: 'https://github.com/authpass/authpass/',
-              ),
               const SizedBox(height: 32),
               Text(
                 loc.aboutLogFile(logFiles.isEmpty

--- a/authpass/lib/ui/screens/about.dart
+++ b/authpass/lib/ui/screens/about.dart
@@ -6,6 +6,8 @@ import 'package:authpass/utils/logging_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
 import 'package:string_literal_finder_annotations/string_literal_finder_annotations.dart';
 
@@ -47,6 +49,30 @@ class AuthPassAboutDialog extends StatelessWidget {
             applicationVersion: appInfo?.versionLabel,
             applicationLegalese: '© by Herbert Poul, 2019-2021', // NON-NLS
             children: <Widget>[
+              const SizedBox(height: 32),
+              FutureBuilder(
+                  future: http.read(Uri.parse(
+                      'https://raw.githubusercontent.com/authpass/authpass/master/CONTRIBUTORS.md')),
+                  builder:
+                      (BuildContext context, AsyncSnapshot<String> snapshot) {
+                    if (snapshot.hasData) {
+                      return MarkdownBody(
+                        data: snapshot.data!,
+                        imageBuilder: (uri, title, alt) {
+                          return const SizedBox.shrink(); // Remove images
+                        },
+                        listItemCrossAxisAlignment:
+                            MarkdownListItemCrossAxisAlignment.start,
+                        onTapLink: (text, url, title) {
+                          DialogUtils.openUrl(url!);
+                        },
+                      );
+                    }
+
+                    return const Center(
+                      child: CircularProgressIndicator(),
+                    );
+                  }),
               const SizedBox(height: 32),
               UrlLink(
                 caption: loc.aboutLinkFeedback,

--- a/authpass/lib/ui/screens/about.dart
+++ b/authpass/lib/ui/screens/about.dart
@@ -76,7 +76,9 @@ class AuthPassAboutDialog extends StatelessWidget {
                         listItemCrossAxisAlignment:
                             MarkdownListItemCrossAxisAlignment.start,
                         onTapLink: (text, url, title) {
-                          DialogUtils.openUrl(url!);
+                          if (url != null) {
+                            DialogUtils.openUrl(url);
+                          }
                         },
                       );
                     }

--- a/authpass/pubspec.lock
+++ b/authpass/pubspec.lock
@@ -555,6 +555,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.2"
   flutter_speed_dial:
     dependency: "direct main"
     description:
@@ -831,6 +838,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:

--- a/authpass/pubspec.yaml
+++ b/authpass/pubspec.yaml
@@ -261,6 +261,7 @@ flutter:
   # To add assets to your application, add an assets section, like this:
   assets:
     - assets/images/
+    - assets/CONTRIBUTORS.md
   #  - images/a_dot_ham.jpeg
 
   fonts:

--- a/authpass/pubspec.yaml
+++ b/authpass/pubspec.yaml
@@ -173,7 +173,9 @@ dependencies:
       ref: 1e124a5056709c00ec05f2c1e3bd8c2084fe962b
   share: ^2.0.1
   collection: ^1.15.0-nullsafety.4
-  
+
+  flutter_markdown: ^0.6.2
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION

Fixes #156

In about dialog, I fetch content of CONTRIBUTORS.md from `https://raw.githubusercontent.com/authpass/authpass/master/CONTRIBUTORS.md`. Then render it with flutter_markdown package.

![image](https://user-images.githubusercontent.com/3256261/125653335-9a50bd4e-2e6d-4468-be86-31c4ea630d45.png)
