### PR TITLE
Added Flatpak build

### DIFF
--- a/.github/workflows/linux_flatpak.yaml
+++ b/.github/workflows/linux_flatpak.yaml
@@ -1,0 +1,26 @@
+on:
+  push:
+    branches:
+      - main
+      - 'linux**'
+  pull_request:
+name: linux_flatpak
+jobs:
+  flatpak:
+    name: "Flatpak"
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-40
+      options: --privileged
+    steps:
+    - uses: actions/checkout@v3
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+      with:
+        bundle: authpass.flatpak
+        manifest-path: flatpak/app.authpass.AuthPass.yaml
+        cache-key: flatpak-builder-${{ github.sha }}
+    - uses: actions/upload-artifact@v3
+      with:
+        name: authpass.flatpak
+        path: authpass.flatpak
+        if-no-files-found: error

--- a/flatpak/app.authpass.AuthPass.desktop
+++ b/flatpak/app.authpass.AuthPass.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=AuthPass
+GenericName=Password Manager
+Type=Application
+Exec=authpass
+Terminal=false
+Icon=app.authpass.AuthPass
+Categories=Utility;Security;

--- a/flatpak/app.authpass.AuthPass.metainfo.xml
+++ b/flatpak/app.authpass.AuthPass.metainfo.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+        <id>app.authpass.AuthPass</id>
+
+        <name>AuthPass</name>
+        <summary>Password Manager: Keep your passwords safe across all platforms and devices</summary>
+
+        <metadata_license>MIT</metadata_license>
+        <project_license>GPL-3.0-or-later</project_license>
+
+        <supports>
+                <control>pointing</control>
+                <control>keyboard</control>
+                <control>touch</control>
+        </supports>
+
+        <description>
+                <p>
+      Easily and securely keep track of all your Passwords!
+    </p>
+                <p>
+      AuthPass is a stand alone password manager with support for the popular and proven KeePass (kdbx 3.x AND kdbx 4.x) format. Store your passwords, share across all your devices and easily find them whenever you need to login.
+    </p>
+                <p>
+                        <em> All your passwords in one place. </em>
+                        Generate secure random passwords for each of your accounts.
+                        <em> Keep track of your accounts across the web. </em>
+                        App available for Mac, iPhone, iPad, Android Phones and Tablets, Linux and Windows.
+                        <em> Open multiple password files at the same time (e.g. one for work, one for personal - or even share your password files with coworkers) </em>
+                        Open Source available on https://github.com/authpass/authpass/ * Dark Theme
+                </p>
+                <p>
+        === UNDER YOUR CONTROL === AuthPass stores all your passwords in the open Keepass format, exactly where you want it. It does not send your passwords to our servers. But AuthPass supports saving to:
+      </p>
+                <p>
+                        <em> Any local content provider from Android </em>
+                        Native Google Drive Integration
+                        <em> Native Dropbox Integation </em>
+                        Native WebDAV support to store in your own NextCloud or OwnCloud (or similar) * Native Microsoft OneDrive integration
+                </p>
+                <p>
+          === FULL FEATURED, NO ADS, NO SUBSCRIPTION === As an open source project there are no artificial feature restrictions, no ads and no requirement for payments.
+        </p>
+                <p>
+                        <em>Contributions welcome and encouraged</em>
+                        ;-) (Always looking for developers, translators, documentation writers, UI designer, etc. :) ), just join our discord channel: https://authpass.app/go/discord
+                </p>
+                <p>
+            === UNDER ACTIVE DEVELOPMENT === This is an open source project which is still under heavy development, adding features. We would love your feedback via email or on the issue tracker at https://github.com/authpass/authpass/issues/
+          </p>
+                <p>
+            Also join the community on our discord channel at https://authpass.app/go/discord
+          </p>
+        </description>
+
+        <launchable type="desktop-id">app.authpass.AuthPass.desktop</launchable>
+        <screenshots>
+                <screenshot type="default">
+                        <image>https://data.authpass.app/data/screenshot_composition.png</image>
+                </screenshot>
+        </screenshots>
+</component>

--- a/flatpak/app.authpass.AuthPass.png
+++ b/flatpak/app.authpass.AuthPass.png
@@ -1,0 +1,1 @@
+../snap/gui/authpass.png

--- a/flatpak/app.authpass.AuthPass.yaml
+++ b/flatpak/app.authpass.AuthPass.yaml
@@ -31,19 +31,19 @@ modules:
   
   - name: authpass
     buildsystem: simple
+    build-options:
+      build-args:
+        - --share=network
     build-commands:
-      - cp authpass /app/
-      - cp -r data /app/
-      - cp -r lib /app/
+      - curl -L https://data.authpass.app/data/artifacts/authpass-linux-latest.tar.gz -O
+      - tar -zxf authpass-linux-latest.tar.gz
+      - cp -r authpass/* /app/
       - chmod +x /app/authpass
       - mkdir -p /app/bin
       - ln -s /app/authpass /app/bin/authpass
       - install -Dm644 app.authpass.AuthPass.png /app/share/icons/hicolor/512x512/apps/app.authpass.AuthPass.png
       - install -Dm644 app.authpass.AuthPass.desktop /app/share/applications/app.authpass.AuthPass.desktop
     sources:
-      - type: archive
-        url: https://data.authpass.app/data/artifacts/authpass-linux-1.9.5_1873.tar.gz
-        sha256: 62595c2b047cab0f9e63bdd83f85db14657eff1e1c5a90a9a82558a29ac6fb69
       - type: file
         path: app.authpass.AuthPass.png
       - type: file

--- a/flatpak/app.authpass.AuthPass.yaml
+++ b/flatpak/app.authpass.AuthPass.yaml
@@ -31,11 +31,11 @@ modules:
   
   - name: authpass
     buildsystem: simple
-    build-options:
-      build-args:
-        - --share=network
+    # build-options:
+    #   build-args:
+    #     - --share=network
     build-commands:
-      - curl -L https://data.authpass.app/data/artifacts/authpass-linux-latest.tar.gz -O
+      # - curl -L https://data.authpass.app/data/artifacts/authpass-linux-latest.tar.gz -O
       - tar -zxf authpass-linux-latest.tar.gz
       - cp -r authpass/* /app/
       - chmod +x /app/authpass
@@ -44,6 +44,14 @@ modules:
       - install -Dm644 app.authpass.AuthPass.png /app/share/icons/hicolor/512x512/apps/app.authpass.AuthPass.png
       - install -Dm644 app.authpass.AuthPass.desktop /app/share/applications/app.authpass.AuthPass.desktop
     sources:
+      - type: file
+        url: https://data.authpass.app/data/artifacts/authpass-linux-1.9.6_1921.tar.gz
+        sha512: 16daa9ca30dce002c1a4900139ba8819247f27d75a298362ba438ee8be4adb1ac3c3fd22d4600624f443781cc2bcf4229f4a2c767b181841b28c579fe97a7909
+        dest-filename: authpass-linux-latest.tar.gz
+        x-checker-data:
+          type: rotating-url
+          url: https://data.authpass.app/data/artifacts/authpass-linux-latest.tar.gz.txt
+          pattern: https://data.authpass.app/data/artifacts/authpass-linux-(.+).tar.gz
       - type: file
         path: app.authpass.AuthPass.png
       - type: file

--- a/flatpak/app.authpass.AuthPass.yaml
+++ b/flatpak/app.authpass.AuthPass.yaml
@@ -43,6 +43,7 @@ modules:
       - ln -s /app/authpass /app/bin/authpass
       - install -Dm644 app.authpass.AuthPass.png /app/share/icons/hicolor/512x512/apps/app.authpass.AuthPass.png
       - install -Dm644 app.authpass.AuthPass.desktop /app/share/applications/app.authpass.AuthPass.desktop
+      - install -Dpm644 app.authpass.AuthPass.metainfo.xml /app/share/metainfo/app.authpass.AuthPass.metainfo.xml
     sources:
       - type: file
         url: https://data.authpass.app/data/artifacts/authpass-linux-1.9.6_1921.tar.gz
@@ -50,9 +51,11 @@ modules:
         dest-filename: authpass-linux-latest.tar.gz
         x-checker-data:
           type: rotating-url
-          url: https://data.authpass.app/data/artifacts/authpass-linux-latest.tar.gz.txt
+          url: https://data.authpass.app/data/artifact.download/authpass-linux-stable.tar.gz/version.txt
           pattern: https://data.authpass.app/data/artifacts/authpass-linux-(.+).tar.gz
       - type: file
         path: app.authpass.AuthPass.png
       - type: file
         path: app.authpass.AuthPass.desktop
+      - type: file
+        path: app.authpass.AuthPass.metainfo.xml

--- a/flatpak/app.authpass.AuthPass.yaml
+++ b/flatpak/app.authpass.AuthPass.yaml
@@ -1,0 +1,50 @@
+app-id: app.authpass.AuthPass
+runtime: org.gnome.Platform
+runtime-version: '3.38'
+sdk: org.gnome.Sdk
+
+command: authpass
+finish-args:
+  # Filesystem and network access
+  - --filesystem=home
+  - --share=network
+  # Display access
+  - --socket=wayland
+  - --share=ipc
+  - --socket=fallback-x11
+  # Keyring access
+  - --talk-name=org.freedesktop.secrets
+  # OpenGL rendering
+  - --device=dri
+
+cleanup:
+  - /include
+  - /lib/debug
+
+modules:
+  - name: libkeybinder
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://github.com/kupferlauncher/keybinder/releases/download/keybinder-3.0-v0.3.2/keybinder-3.0-0.3.2.tar.gz
+        sha256: e6e3de4e1f3b201814a956ab8f16dfc8a262db1937ff1eee4d855365398c6020
+  
+  - name: authpass
+    buildsystem: simple
+    build-commands:
+      - cp authpass /app/
+      - cp -r data /app/
+      - cp -r lib /app/
+      - chmod +x /app/authpass
+      - mkdir -p /app/bin
+      - ln -s /app/authpass /app/bin/authpass
+      - install -Dm644 app.authpass.AuthPass.png /app/share/icons/hicolor/512x512/apps/app.authpass.AuthPass.png
+      - install -Dm644 app.authpass.AuthPass.desktop /app/share/applications/app.authpass.AuthPass.desktop
+    sources:
+      - type: archive
+        url: https://data.authpass.app/data/artifacts/authpass-linux-1.9.5_1873.tar.gz
+        sha256: 62595c2b047cab0f9e63bdd83f85db14657eff1e1c5a90a9a82558a29ac6fb69
+      - type: file
+        path: app.authpass.AuthPass.png
+      - type: file
+        path: app.authpass.AuthPass.desktop


### PR DESCRIPTION
## Summary
Created Flatpak build for AuthPass. Resolves #271.

## Changes
* Added a manifest and files to project that allowing for bundling AuthPass as a Flatpak
* Modified GitHub workflows to build the Flatpak and upload it

## Notes
* Flatpak seems to really want to make things hard to do dynamically. It requires you to know the hash of any downloaded sources beforehand (see my [earlier commit](https://github.com/authpass/authpass/blob/8c43b20a70a5afe5c1e75cf24772e6a247c08a46/flatpak/app.authpass.AuthPass.yaml#L44-L46)), and the build is run in a sandbox so it has no access to any external environment variables (I was planning on passing in an environment variable from the GitHub workflow that contained the computed hash of the latest release of AuthPass). After trying everything, I had to settle for this slightly hacky way of downloading the latest version while skipping its hash verification.
* In its current state, this does not push the build artifact to any Flatpak app repo (it _does_ still upload the file to AuthPass's own artifact store though). However, I can put in a request with [Flathub](https://flathub.org/home) to [host the app](https://github.com/flathub/flathub/wiki/App-Submission), if you would like! I looked into it a bit, and it seems it would require some changes and manual updates. [This repo](https://github.com/flathub/flatpak-external-data-checker) may be able to solve some of those problems (see [here](https://discourse.flathub.org/t/tools-for-automatically-updating-flatpak-packaging/736)).