### PR TITLE
actions workflow to build debs

### DIFF
--- a/.github/workflows/make_deb.yml
+++ b/.github/workflows/make_deb.yml
@@ -4,27 +4,45 @@ on:
   push:
     branches:
       - 'main'
+      - 'linux**'
+  workflow_run:
+    workflows: ["build linux"]
+    types: [completed]
+  workflow_dispatch:
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - run: |
-          cd debian/opt/authpass
+      - uses: actions/checkout@v3
+      - name: Postdeploy
+        env:
+          BLACKBOX_SECRET: ${{ secrets.BLACKBOX_SECRET_KEY }}
+        run: authpass/_tools/postdeploy.sh
+      - id: build
+        run: |
+          path=debian/opt/authpass
+          cd "$path"
           wget https://authpass-data.codeux.design/data/artifacts/authpass-linux-latest.tar.gz
           tar -zxvf authpass-linux-latest.tar.gz authpass -C . --strip-components=1
           rm authpass-linux-latest.tar.gz
           version=$(cat version.txt)
+          version_name=${version/+/_}
+          filename="authpass-linux-${version_name}.deb"
           cd ../../../
           sed -i "s/1.0/${version}/g" debian/usr/share/applications/authpass.desktop
           sed -i "s/1.0/${version}/g" debian/DEBIAN/control
           dpkg-deb --build --root-owner-group ./debian 
-          mv debian.deb authpass.deb
+          mv debian.deb $filename
+          echo "::set-output name=outputfilename::${filename}"
+          echo "::set-output name=outputpath::${filename}"
+      - name: upload artifact
+        run: ./authpass/_tools/upload-artifact.sh ${{ steps.build.outputs.outputfilename }}
       - uses: actions/upload-artifact@v3
         with:
-          name: authpass
-          path: authpass.deb
+          name: ${{ steps.build.outputs.outputfilename }}
+          path: ${{ steps.build.outputs.outputpath }}
+          if-no-files-found: error
 
 #tar -zxvf authpass-linux-latest.tar.gz authpass/. -C .

--- a/.github/workflows/make_deb.yml
+++ b/.github/workflows/make_deb.yml
@@ -1,0 +1,27 @@
+name: make_deb
+
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          cd debian/opt/authpass
+          wget https://authpass-data.codeux.design/data/artifacts/authpass-linux-latest.tar.gz
+          tar -zxvf authpass-linux-latest.tar.gz authpass -C . --strip-components=1
+          rm authpass-linux-latest.tar.gz
+          cd ../../../
+          dpkg-deb --build --root-owner-group ./debian 
+          mv debian.deb authpass.deb
+      - uses: actions/upload-artifact@v3
+        with:
+          name: authpass
+          path: authpass.deb
+
+#tar -zxvf authpass-linux-latest.tar.gz authpass/. -C .

--- a/.github/workflows/make_deb.yml
+++ b/.github/workflows/make_deb.yml
@@ -44,5 +44,3 @@ jobs:
           name: ${{ steps.build.outputs.outputfilename }}
           path: ${{ steps.build.outputs.outputpath }}
           if-no-files-found: error
-
-#tar -zxvf authpass-linux-latest.tar.gz authpass/. -C .

--- a/.github/workflows/make_deb.yml
+++ b/.github/workflows/make_deb.yml
@@ -16,7 +16,10 @@ jobs:
           wget https://authpass-data.codeux.design/data/artifacts/authpass-linux-latest.tar.gz
           tar -zxvf authpass-linux-latest.tar.gz authpass -C . --strip-components=1
           rm authpass-linux-latest.tar.gz
+          version=$(cat version.txt)
           cd ../../../
+          sed -i "s/1.0/${version}/g" debian/usr/share/applications/authpass.desktop
+          sed -i "s/1.0/${version}/g" debian/DEBIAN/control
           dpkg-deb --build --root-owner-group ./debian 
           mv debian.deb authpass.deb
       - uses: actions/upload-artifact@v3

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -1,0 +1,5 @@
+Package: authpass
+Version: 1.0
+Architecture: amd64
+Maintainer: Herbert Poul
+Description: AuthPass - Password Manager based on Flutter for all platforms. Keepass 2.x (kdbx 3.x) compatible.

--- a/debian/DEBIAN/postinst
+++ b/debian/DEBIAN/postinst
@@ -1,0 +1,2 @@
+#!/bin/bash
+ln -s /opt/authpass/authpass /usr/bin/authpass

--- a/debian/DEBIAN/postrm
+++ b/debian/DEBIAN/postrm
@@ -1,0 +1,2 @@
+#!/bin/bash
+rm /usr/bin/authpass

--- a/debian/opt/authpass/icon.svg
+++ b/debian/opt/authpass/icon.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1024px" height="1024px" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 57.1 (83088) - https://sketch.com -->
+    <title>AuthPassMacLogoOutline Copy</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <path d="M864,256 C881.673112,256 896,270.326888 896,288 L896,352 C896,369.673112 881.673112,384 864,384 L832,384 L832,505.6 C832,509.134622 829.134622,512 825.6,512 L774.4,512 C770.865378,512 768,509.134622 768,505.6 L768,454.4 C768,450.865378 765.134622,448 761.6,448 L710.4,448 C706.865378,448 704,450.865378 704,454.4 L704,569.6 C704,573.134622 701.134622,576 697.6,576 L646.4,576 C642.865378,576 640,573.134622 640,569.6 L640,390.4 C640,386.865378 637.134622,384 633.6,384 L487.554175,384 C463.312764,384 441.151924,397.696152 430.310835,419.37833 L320,640 L116.46745,640 C85.9598645,640 59.6933162,618.466581 53.7102865,588.551433 L0.251028653,321.255143 C0.0853170855,320.426585 0.0853170855,319.573415 0.251028653,318.744857 L53.7102865,51.4485674 C59.6933162,21.5334188 85.9598645,0 116.46745,0 L320,0 L430.310835,220.62167 C441.151924,242.303848 463.312764,256 487.554175,256 L864,256 Z" id="path-1"></path>
+    </defs>
+    <g id="AuthPassMacLogoOutline-Copy" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Logo-Final-2" transform="translate(64.000000, 191.000000)">
+            <g id="Logo-Final">
+                <mask id="mask-2" fill="white">
+                    <use xlink:href="#path-1"></use>
+                </mask>
+                <use id="Key" fill="#626BC6" xlink:href="#path-1"></use>
+                <rect id="Rectangle" fill="#8A93EE" mask="url(#mask-2)" x="-64" y="256" width="1024" height="128"></rect>
+                <rect id="Rectangle" fill="#6B6F99" mask="url(#mask-2)" x="-64" y="384" width="1024" height="256"></rect>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/debian/usr/share/applications/authpass.desktop
+++ b/debian/usr/share/applications/authpass.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Name=authpass
+GenericName=Password Manager
+Comment=Manage your passwords
+Exec=/usr/bin/authpass
+StartupNotify=true
+Terminal=false
+Type=Application
+Categories=Network;
+Icon=/opt/authpass/icon.svg


### PR DESCRIPTION
In this pull request i added a github actions workflow and debian folder with all of the nescesary items to go and build a debian package as an artifact (the item of the workflow). it uses the latest release and builds a deb file. the only problem rn is, that it doesnt automatcially update the version info of the deb. (i will prob look at it soon and make a new pr!)

Context: #272 