### PR TITLE
Add possibility to re-trigger quick unlock when cancelled and show quick unlocked saved files

### DIFF
--- a/authpass/lib/bloc/app_data.dart
+++ b/authpass/lib/bloc/app_data.dart
@@ -190,6 +190,8 @@ abstract class AppData implements Built<AppData, AppDataBuilder>, HasToJson {
 
   BuiltList<OpenedFile> get previousFiles;
 
+  BuiltList<OpenedFile> get quickUnlockFiles;
+
   int? get passwordGeneratorLength;
 
   BuiltSet<String> get passwordGeneratorCharacterSets;

--- a/authpass/lib/bloc/app_data.g.dart
+++ b/authpass/lib/bloc/app_data.g.dart
@@ -150,6 +150,10 @@ class _$AppDataSerializer implements StructuredSerializer<AppData> {
       serializers.serialize(object.previousFiles,
           specifiedType:
               const FullType(BuiltList, const [const FullType(OpenedFile)])),
+      'quickUnlockFiles',
+      serializers.serialize(object.quickUnlockFiles,
+          specifiedType:
+          const FullType(BuiltList, const [const FullType(OpenedFile)])),
       'passwordGeneratorCharacterSets',
       serializers.serialize(object.passwordGeneratorCharacterSets,
           specifiedType:
@@ -282,6 +286,12 @@ class _$AppDataSerializer implements StructuredSerializer<AppData> {
                   specifiedType: const FullType(
                       BuiltList, const [const FullType(OpenedFile)]))!
               as BuiltList<Object?>);
+          break;
+        case 'quickUnlockFiles':
+          result.quickUnlockFiles.replace(serializers.deserialize(value,
+              specifiedType: const FullType(
+                  BuiltList, const [const FullType(OpenedFile)]))!
+          as BuiltList<Object?>);
           break;
         case 'passwordGeneratorLength':
           result.passwordGeneratorLength = serializers.deserialize(value,
@@ -561,6 +571,8 @@ class _$AppData extends AppData {
   @override
   final BuiltList<OpenedFile> previousFiles;
   @override
+  final BuiltList<OpenedFile> quickUnlockFiles;
+  @override
   final int? passwordGeneratorLength;
   @override
   final BuiltSet<String> passwordGeneratorCharacterSets;
@@ -600,6 +612,7 @@ class _$AppData extends AppData {
 
   _$AppData._(
       {required this.previousFiles,
+      required this.quickUnlockFiles,
       this.passwordGeneratorLength,
       required this.passwordGeneratorCharacterSets,
       this.manualUserType,
@@ -620,6 +633,8 @@ class _$AppData extends AppData {
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
         previousFiles, r'AppData', 'previousFiles');
+    BuiltValueNullFieldError.checkNotNull(
+        quickUnlockFiles, r'AppData', 'quickUnlockFiles');
     BuiltValueNullFieldError.checkNotNull(passwordGeneratorCharacterSets,
         r'AppData', 'passwordGeneratorCharacterSets');
     BuiltValueNullFieldError.checkNotNull(
@@ -638,6 +653,7 @@ class _$AppData extends AppData {
     if (identical(other, this)) return true;
     return other is AppData &&
         previousFiles == other.previousFiles &&
+        quickUnlockFiles == other.quickUnlockFiles &&
         passwordGeneratorLength == other.passwordGeneratorLength &&
         passwordGeneratorCharacterSets ==
             other.passwordGeneratorCharacterSets &&
@@ -678,8 +694,11 @@ class _$AppData extends AppData {
                                                                 $jc(
                                                                     $jc(
                                                                         $jc(
-                                                                            0,
-                                                                            previousFiles
+                                                                            $jc(
+                                                                                0,
+                                                                                previousFiles
+                                                                                    .hashCode),
+                                                                            quickUnlockFiles
                                                                                 .hashCode),
                                                                         passwordGeneratorLength
                                                                             .hashCode),
@@ -710,6 +729,7 @@ class _$AppData extends AppData {
   String toString() {
     return (newBuiltValueToStringHelper(r'AppData')
           ..add('previousFiles', previousFiles)
+          ..add('quickUnlockFiles', quickUnlockFiles)
           ..add('passwordGeneratorLength', passwordGeneratorLength)
           ..add(
               'passwordGeneratorCharacterSets', passwordGeneratorCharacterSets)
@@ -740,6 +760,12 @@ class AppDataBuilder implements Builder<AppData, AppDataBuilder> {
       _$this._previousFiles ??= new ListBuilder<OpenedFile>();
   set previousFiles(ListBuilder<OpenedFile>? previousFiles) =>
       _$this._previousFiles = previousFiles;
+
+  ListBuilder<OpenedFile>? _quickUnlockFiles;
+  ListBuilder<OpenedFile> get quickUnlockFiles =>
+      _$this._quickUnlockFiles ??= new ListBuilder<OpenedFile>();
+  set quickUnlockFiles(ListBuilder<OpenedFile>? quickUnlockFiles) =>
+      _$this._quickUnlockFiles = quickUnlockFiles;
 
   int? _passwordGeneratorLength;
   int? get passwordGeneratorLength => _$this._passwordGeneratorLength;
@@ -833,6 +859,7 @@ class AppDataBuilder implements Builder<AppData, AppDataBuilder> {
     final $v = _$v;
     if ($v != null) {
       _previousFiles = $v.previousFiles.toBuilder();
+      _quickUnlockFiles = $v.quickUnlockFiles.toBuilder();
       _passwordGeneratorLength = $v.passwordGeneratorLength;
       _passwordGeneratorCharacterSets =
           $v.passwordGeneratorCharacterSets.toBuilder();
@@ -876,6 +903,7 @@ class AppDataBuilder implements Builder<AppData, AppDataBuilder> {
       _$result = _$v ??
           new _$AppData._(
               previousFiles: previousFiles.build(),
+              quickUnlockFiles: quickUnlockFiles.build(),
               passwordGeneratorLength: passwordGeneratorLength,
               passwordGeneratorCharacterSets:
                   passwordGeneratorCharacterSets.build(),
@@ -900,6 +928,9 @@ class AppDataBuilder implements Builder<AppData, AppDataBuilder> {
       try {
         _$failedField = 'previousFiles';
         previousFiles.build();
+
+        _$failedField = 'quickUnlockFiles';
+        quickUnlockFiles.build();
 
         _$failedField = 'passwordGeneratorCharacterSets';
         passwordGeneratorCharacterSets.build();

--- a/authpass/lib/bloc/kdbx_bloc.dart
+++ b/authpass/lib/bloc/kdbx_bloc.dart
@@ -418,6 +418,9 @@ class KdbxBloc {
     if (addToQuickUnlock) {
       _openedFilesQuickUnlock.add(file);
       _logger.fine('adding file to quick unlock.');
+      await appDataBloc.update((b, data) {
+        b.quickUnlockFiles.add(openedFile);
+      });
       await _updateQuickUnlockStore();
     }
     return kdbxOpenedFile;
@@ -547,6 +550,10 @@ class KdbxBloc {
       // clear all quick unlock data.
       _openedFilesQuickUnlock.clear();
       await quickUnlockStorage.updateQuickUnlockFile({});
+      await appDataBloc.update(
+              (builder, data) {
+            builder.quickUnlockFiles.clear();
+          });
       analytics.events.trackCloseAllFiles(count: _openedFiles.value.length);
     } else {
       analytics.events.trackLockAllFiles(count: _openedFiles.value.length);

--- a/authpass/lib/l10n/app_en.arb
+++ b/authpass/lib/l10n/app_en.arb
@@ -1748,5 +1748,9 @@
         "type": "String"
       }
     }
-  }
+  },
+  "quickunlockableFiles": "Quick unlockable files:",
+    "@quickunlockableFiles": {
+      "description": "title of list with quick unlockable files."
+    }
 }

--- a/authpass/lib/ui/screens/select_file_screen.dart
+++ b/authpass/lib/ui/screens/select_file_screen.dart
@@ -321,6 +321,44 @@ class _SelectFileWidgetState extends State<SelectFileWidget>
             mainAxisAlignment: MainAxisAlignment.center,
             mainAxisSize: MainAxisSize.max,
             children: <Widget>[
+              IntrinsicWidth(
+                stepWidth: 100,
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 400),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: <Widget>[
+                      ...?(appData.quickUnlockFiles.isNotEmpty ? [
+                        const SizedBox(height: 16),
+                        Text(
+                          loc.quickunlockableFiles,
+                          style: theme.textTheme.caption,
+                          textAlign: TextAlign.center,
+                        ),
+                        ...ListTile.divideTiles(
+                          context: context,
+                          tiles: appData.quickUnlockFiles.map(
+                                (f) => OpenedFileTile(
+                              openedFile:
+                              f.toFileSource(cloudStorageBloc),
+                              color: f.color,
+                            ),
+                          )
+                        ),
+                        LinkButton(
+                          icon: const Icon(Icons.lock_open),
+                          onPressed: () {
+                            _quickUnlockAttempted = false;
+                            _checkQuickUnlock();
+                          },
+                          child: Text(loc.unlock),
+                        )
+                      ] : null)
+                    ],
+                  ),
+                ),
+              ),
               ...?(_showLinuxAppArmorMessage
                   ? [
                       const SizedBox(height: 16),
@@ -732,7 +770,7 @@ class OpenedFileTile extends StatelessWidget {
                 ],
               ),
             ),
-            IconButton(
+            if(onLongPressed != null) IconButton(
               onPressed: onLongPressed,
               icon: const Icon(Icons.more_vert),
             )


### PR DESCRIPTION
The quick unlock feature is very useful for me but unfortunately is it not possible to quick unlock the saved files when the biometric prompt was cancelled. Therefore the app must be closed and re-opened.
This PR adds a button to re-trigger the quick unlock attempt.

Additionally a list with the quick unlocked saved databases is shown for the user to know which databases gets quick unlocked.
To show the databases without unlocking the biometric storage the list is saved additionally to the previous files list.

It would be great when this PR gets merged :-)