### PR TITLE
Add debug possibilities for offline access

### DIFF
--- a/authpass/lib/bloc/kdbx/file_source_cloud_storage.dart
+++ b/authpass/lib/bloc/kdbx/file_source_cloud_storage.dart
@@ -92,8 +92,9 @@ class FileSourceCloudStorage extends FileSource {
     final cacheDir = _cacheDir ??= await _getCacheDir();
     final metadataFile = _cacheMetadataFile(cacheDir);
     final kdbxFile = _cacheKdbxFile(cacheDir);
+    final cacheAvailable = metadataFile.existsSync() && kdbxFile.existsSync();
     try {
-      if (metadataFile.existsSync()) {
+      if (metadataFile.existsSync() && kdbxFile.existsSync()) {
         final cacheInfo = FileContentCached.fromJson(json
             .decode(await metadataFile.readAsString()) as Map<String, dynamic>);
         final content = await kdbxFile.readAsBytes();
@@ -116,7 +117,10 @@ class FileSourceCloudStorage extends FileSource {
     } catch (e, stackTrace) {
       _logger.severe('Error while loading file from provider ${toString()}', e,
           stackTrace);
-      rethrow;
+      if(cacheAvailable){
+        throw LoadFileException('Error loading file from provider ${toString()}.');
+      }
+      throw LoadFileException('Error loading file from cache and provider ${toString()}.');
     }
   }
 

--- a/authpass/lib/bloc/kdbx_bloc.dart
+++ b/authpass/lib/bloc/kdbx_bloc.dart
@@ -506,6 +506,7 @@ class KdbxBloc {
                   'quick unlock. ignoring file for now. ${file.key}',
                   e,
                   stackTrace);
+              rethrow;
             }
           }
           analytics.events.trackQuickUnlock(value: filesOpened);


### PR DESCRIPTION
Apparently the cached version of a file is sometimes no longer available. This PR add some messages to determine this behaviour.

Afterwards it could be investigated if and why the cached version of a file is not available.