### PR TITLE
Fix missing cached database when storage is low

### DIFF
--- a/authpass/lib/bloc/kdbx/file_source_cloud_storage.dart
+++ b/authpass/lib/bloc/kdbx/file_source_cloud_storage.dart
@@ -64,7 +64,7 @@ class FileSourceCloudStorage extends FileSource {
   static Directory? _cacheDir;
 
   Future<Directory> _getCacheDir() => provider.pathUtil
-      .getTemporaryDirectory(subNamespace: 'cloud_storage_cache');
+      .getApplicationSupportDirectory(subNamespace: 'cloud_storage_cache');
 
   final CloudStorageProvider provider;
 
@@ -93,7 +93,7 @@ class FileSourceCloudStorage extends FileSource {
     final metadataFile = _cacheMetadataFile(cacheDir);
     final kdbxFile = _cacheKdbxFile(cacheDir);
     try {
-      if (metadataFile.existsSync()) {
+      if (metadataFile.existsSync() && kdbxFile.existsSync()) {
         final cacheInfo = FileContentCached.fromJson(json
             .decode(await metadataFile.readAsString()) as Map<String, dynamic>);
         final content = await kdbxFile.readAsBytes();
@@ -102,6 +102,8 @@ class FileSourceCloudStorage extends FileSource {
               'cache file. ${content.length} vs $cacheInfo');
         }
         yield FileContent(content, cacheInfo.metadata, FileContentSource.cache);
+      }else{
+        _logger.severe('The cached kdbx file is not available!', );
       }
     } catch (e, stackTrace) {
       _logger.severe('Error while loading cached kdbx file', e, stackTrace);

--- a/authpass/lib/bloc/kdbx_bloc.dart
+++ b/authpass/lib/bloc/kdbx_bloc.dart
@@ -506,6 +506,7 @@ class KdbxBloc {
                   'quick unlock. ignoring file for now. ${file.key}',
                   e,
                   stackTrace);
+              rethrow;
             }
           }
           analytics.events.trackQuickUnlock(value: filesOpened);

--- a/authpass/lib/utils/path_util.dart
+++ b/authpass/lib/utils/path_util.dart
@@ -7,6 +7,10 @@ abstract class PathUtil {
   /// Directory for temporary files which are typically cleared each app restart.
   Future<Directory> getTemporaryDirectory({@NonNls String? subNamespace});
 
-  /// Directory for caches which survive application restart.
+  /// Directory for caches which survive application restart but is not permanent.
+  /// Files in this directory may be cleared at any time
   Future<Directory> getCacheDirectory({@NonNls String? subNamespace});
+
+  /// Directory for caches which survive application restart and is not cleared.
+  Future<Directory> getApplicationSupportDirectory({@NonNls String? subNamespace});
 }

--- a/authpass/lib/utils/path_utils.dart
+++ b/authpass/lib/utils/path_utils.dart
@@ -88,6 +88,15 @@ abstract class PathUtilsDefault extends PathUtils {
     );
   }
 
+  @NonNls
+  @override
+  Future<Directory> getApplicationSupportDirectory({String? subNamespace}) async {
+    return directoryCache[_cacheKey('cloudcache', subNamespace)] ??= _namespaced(
+      await retrieveApplicationSupportDirectory(),
+      subNamespace: subNamespace,
+    );
+  }
+
   @protected
   @visibleForOverriding
   Future<Directory> retrieveTemporaryDirectory();
@@ -100,6 +109,8 @@ abstract class PathUtilsDefault extends PathUtils {
   @protected
   @visibleForOverriding
   Future<Directory> retrieveAppDataDirectory();
+  @visibleForOverriding
+  Future<Directory> retrieveApplicationSupportDirectory();
 
   /// Document directory for "internal" kdbx files which should be accessible
   /// by the user. - this directory is NOT namespaced during development.

--- a/authpass/lib/utils/path_utils_path_provider.dart
+++ b/authpass/lib/utils/path_utils_path_provider.dart
@@ -48,6 +48,10 @@ class PathUtilsFromPathProvider extends PathUtilsDefault {
     return await _getDesktopAppDataDirectory();
   }
 
+  @override
+  Future<Directory> retrieveApplicationSupportDirectory() async => fileSystem
+      .directory(await path_provider.getApplicationSupportDirectory());
+
   @NonNls
   Future<Directory> _getDesktopAppDataDirectory() async {
     // https://stackoverflow.com/a/32937974/109219

--- a/authpass/lib/utils/path_utils_portable.dart
+++ b/authpass/lib/utils/path_utils_portable.dart
@@ -84,4 +84,7 @@ class PathUtilsPortable extends PathUtilsDefault {
   Future<Directory> retrieveTemporaryDirectory() async => _subDir('Temp');
   @override
   Future<Directory> retrieveCacheDirectory() async => _subDir('Cache');
+
+  @override
+  Future<Directory> retrieveApplicationSupportDirectory() async => _subDir('Support');
 }

--- a/authpass/lib/utils/path_utils_web.dart
+++ b/authpass/lib/utils/path_utils_web.dart
@@ -31,4 +31,10 @@ class PathUtilsWeb extends PathUtilsDefault {
   Future<Directory> retrieveCacheDirectory() async {
     return fileSystem.directory('/cache');
   }
+
+  @NonNls
+  @override
+  Future<Directory> retrieveApplicationSupportDirectory() async {
+    return fileSystem.directory('/support');
+  }
 }


### PR DESCRIPTION
The cached database is stored in a temporary folder which could be cleared at any time
(https://pub.dev/documentation/path_provider/latest/path_provider/getTemporaryDirectory.html). Unfortunately sometimes the cached database is no longer available when the app is opened in offline mode.

This PR changes the directory for the cached database to the Application Support Directory
(https://pub.dev/documentation/path_provider/latest/path_provider/getApplicationSupportDirectory.html).

The Application Documents Directory is not used because this directory is already used for local databases and queried when opening local databases.
Since the cached version of databases should not be selected manually the Application Support Directory was chosen.

This PR closes PR #340 which is no longer needed.