### PR TITLE
Add monochrome icon

### DIFF
--- a/authpass/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/authpass/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/authpass/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/authpass/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
Added monochrome icon for Android 13 "Themed icons" support.
![authpass_android_themed_icon_preview](https://github.com/user-attachments/assets/64f7afe0-32c8-4289-a31b-6e802ed81cf3)

