### PR TITLE
upgrade to cux_ship 3.1.0

### DIFF
--- a/authpass/_tools/cux_ship/pubspec.lock
+++ b/authpass/_tools/cux_ship/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: "direct main"
     description:
       name: cux_ship
-      sha256: a56826c848e5705272a6c2ee0c4c0a4c6739c900d2141384013dde5fd5f77297
+      sha256: "81f6f27c7d2cbb73bd39239bf7b5e44a8df2a384d43cde9d02410e19a67ed1a6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.0"
   cux_ship_verify:
     dependency: transitive
     description:

--- a/authpass/_tools/cux_ship/pubspec.yaml
+++ b/authpass/_tools/cux_ship/pubspec.yaml
@@ -18,4 +18,4 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  cux_ship: ^3.0.0
+  cux_ship: ^3.1.0


### PR DESCRIPTION
One constraint, in the one place the wrapper exists to hold it.

3.1.0 adds `--no-metadata` on `appstore upload` and makes the Xcode-project
inference refuse an ambiguous project instead of taking the first match.

Nothing here needs changing for it, and the second half is worth a note because
AuthPass is one of the projects that inference now refuses:

```
ios/Runner.xcodeproj/project.pbxproj names 4 bundle identifiers
(design.codeux.authpass.ios.autofill, design.codeux.authpass.ios,
design.codeux.authpass.ios.debug, design.codeux.authpass.ios.debug.autofill),
so none of them can be assumed to be the app's — pass --bundle-id to choose
```

Under 3.0.0 that returned `design.codeux.authpass.ios.autofill` — the AutoFill
app extension, because its target comes first in the file. Every store command
here passes `--bundle-id` explicitly, so nothing ever used it, and removing that
flag now fails loudly instead of quietly uploading against the appex.

`DEVELOPMENT_TEAM` still infers cleanly (`64ZPC769JY`, six identical entries),
which matters because `keychain exec` passes no `--team`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)