### PR TITLE
Allocate build numbers through the cux_buildnumber port

### DIFF
--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -69,7 +69,7 @@ jobs:
       #
       # `--only` is the other half. 3.0.0 gives the child the keychain and
       # nothing else, so what the build consumes is named here rather than
-      # subtracted downstream: the deploy key, for `git-buildnumber.sh
+      # subtracted downstream: the deploy key, for `ship.sh buildnumber
       # generate`. APPLE_KEYCHAIN arrives on its own. This replaced a ten-line
       # `unset` denylist in ci-release.sh, which was fail-open — every
       # credential added to the secrets file reached xcodebuild until somebody
@@ -87,7 +87,7 @@ jobs:
 
       # No keychain: nothing here signs. The build number comes from the file
       # the build step wrote, because the two must publish the same one and
-      # only the first allocates — `git-buildnumber.sh generate` pushes a ref to
+      # only the first allocates — `ship.sh buildnumber generate` pushes a ref to
       # claim it, so calling it twice would upload an artifact whose
       # CFBundleVersion is not the one Apple was told about.
       - name: 'upload ${{ matrix.platform }}'

--- a/authpass/_tools/cux_ship/pubspec.lock
+++ b/authpass/_tools/cux_ship/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      sha256: be169cf6ac481e052c4538715d88841d567150dfe1df38aaec76461a4e7b39f2
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.9"
+    version: "4.1.0"
   args:
     dependency: transitive
     description:
@@ -65,22 +65,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cux_buildnumber:
+    dependency: "direct main"
+    description:
+      name: cux_buildnumber
+      sha256: "6993d7c0759baf5675234cbe7ad22c3f1595c1ad92d1765fca84be5732921ff0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0-dev.1"
   cux_ship:
     dependency: "direct main"
     description:
       name: cux_ship
-      sha256: "81f6f27c7d2cbb73bd39239bf7b5e44a8df2a384d43cde9d02410e19a67ed1a6"
+      sha256: "55ef4abc8a6e79e1c67130c5ede4ba44356784d63d59c8c44402d1f113ae1a4a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.4.0-dev.1"
   cux_ship_verify:
     dependency: transitive
     description:
       name: cux_ship_verify
-      sha256: "6ba516d144d17cbbc42b488c767a8b54e819a4db027f758525b454d4bfb61f26"
+      sha256: a1d3b07e8e01c986c4da2b42234eeb00ef8fbe26570ee0b833802c244bee572a
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.0"
   dart_jsonwebtoken:
     dependency: transitive
     description:
@@ -149,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
+      sha256: "1976370a4df3091bb0f72409c187ad1f9132a818bc6b95ca59c0bae1c75c688e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.1"
+    version: "4.9.2"
   meta:
     dependency: transitive
     description:
@@ -169,14 +177,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  petitparser:
-    dependency: transitive
-    description:
-      name: petitparser
-      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.2"
   pointycastle:
     dependency: transitive
     description:
@@ -241,14 +241,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
-  xml:
-    dependency: transitive
-    description:
-      name: xml
-      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.1"
   yaml:
     dependency: transitive
     description:

--- a/authpass/_tools/cux_ship/pubspec.yaml
+++ b/authpass/_tools/cux_ship/pubspec.yaml
@@ -18,4 +18,11 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  cux_ship: ^3.1.0
+  cux_ship: ^3.4.0-dev.1
+  # The git-buildnumber port, invoked through ship.sh's `buildnumber`
+  # dispatch. Replaces the shell script release.sh used to curl from the
+  # mutable `stable` branch and execute — unpinned, unhashed, run on a CI
+  # machine holding push credentials. A separate package from cux_ship (an
+  # allocator whose only dependency is git should not pull googleapis), but
+  # pinned by the same lockfile so there is exactly one place to bump.
+  cux_buildnumber: ^0.1.0-dev.1

--- a/authpass/_tools/release.sh
+++ b/authpass/_tools/release.sh
@@ -31,22 +31,6 @@ ls ${DEPS}/flutter || echo "Flutter not found"
 
 $FLT --version
 
-if ! test -e ./git-buildnumber.sh ; then
-    # --fail matters more than it looks. Without it curl writes the *error body*
-    # to the file, and the next two lines chmod +x it and run it — so a bad day
-    # at raw.githubusercontent.com becomes an executable HTML page. That is not
-    # hypothetical: on 2026-08-17 a 429 during a GitHub outage produced
-    #
-    #     ./git-buildnumber.sh: line 1: 429:: command not found
-    #
-    # and the build number came back empty. --retry covers the transient
-    # statuses (408, 429, 5xx) so the outage is survived rather than merely
-    # reported, and -S keeps the reason visible when it is not.
-    curl -sS --fail --retry 5 --retry-delay 5 \
-        -O https://raw.githubusercontent.com/hpoul/git-buildnumber/stable/git-buildnumber.sh
-    chmod +x git-buildnumber.sh
-fi
-
 # Which half of a release this run does. `all` — the default, and what every
 # platform but ios and macos ever uses — is the behaviour this script has always
 # had. The Apple path splits it into two CI steps, for two reasons:
@@ -67,7 +51,7 @@ esac
 does_phase() { test "${RELEASE_PHASE}" = all -o "${RELEASE_PHASE}" = "$1" ; }
 
 # The two steps must publish the *same* build number, and only the first one
-# allocates. `git-buildnumber.sh generate` pushes a ref to claim it, so calling
+# allocates. `ship.sh buildnumber generate` pushes a ref to claim it, so calling
 # it twice would claim two and upload an artifact whose CFBundleVersion is not
 # the one Apple was told about.
 #
@@ -113,7 +97,14 @@ if test -z "$buildnumber" ; then
       git checkout -- pubspec.lock
       ;;
     esac
-    buildnumber=`./git-buildnumber.sh generate`
+    # The Dart port of git-buildnumber, resolved by _tools/cux_ship's lockfile
+    # like the rest of the release tooling. Replaces a shell script this used
+    # to curl from a mutable branch and execute — unpinned, on a runner
+    # holding push credentials, and one GitHub 429 away from executing an
+    # error page (see the git history of this block). Same command surface:
+    # the number on stdout, logs on stderr, GIT_PUSH_REMOTE and
+    # GIT_SSH_COMMAND honored from the environment.
+    buildnumber=$(./_tools/ship.sh buildnumber generate)
 else
 	echo "WARNING: forcing buildnumber $buildnumber"
 fi

--- a/authpass/_tools/ship.sh
+++ b/authpass/_tools/ship.sh
@@ -36,4 +36,15 @@ if [ ! -f .dart_tool/package_config.json ]; then
   "$dart" pub get >&2
 fi
 
+# The build number allocator. A separate package from cux_ship, resolved by the
+# same lockfile here so there is exactly one pin. Replaces the
+# git-buildnumber.sh release.sh used to curl from a mutable branch and execute.
+# Runs from this directory, which is inside the repository; git does not care
+# where inside, and `generate` prints the number on stdout and everything else
+# on stderr, same as the script it replaces.
+if [ "${1:-}" = "buildnumber" ]; then
+  shift
+  exec "$dart" run cux_buildnumber:git_buildnumber "$@"
+fi
+
 exec "$dart" run cux_ship "$@"


### PR DESCRIPTION
Replaces the git-buildnumber.sh that release.sh curled from the mutable `stable` branch and executed on CI runners holding push credentials — unpinned and unhashed, and one GitHub 429 away from executing an error page (the curl block's own comment records that happening).

The port (`cux_buildnumber` 0.1.0-dev.1, alongside cux_ship 3.4.0-dev.1 in the `_tools/cux_ship` wrapper's lockfile) carries the four upstream fixes: the second-parent reachability edge, the refspec split with `--force-with-lease`, `--first-parent` on the allocation log, and the shallow-clone chain fetch. Invoked through a new `ship.sh buildnumber` dispatch; same command surface as the script it replaces (number on stdout, logs on stderr, `GIT_PUSH_REMOTE`/`GIT_SSH_COMMAND` honored).

Already proven live: builds 2153/2154 were allocated by this port from workflow runs of the precursor branch — fresh depth-1 clones, allocation pushed via the deploy key, and the chain tip on origin now carries the reachability edge.

Not included, deliberately: `provenance.record-uploads` (uploaded/ tagging) stays off until the exit-code handling around Play-duplicate tolerance is done, per docs/design in cux_ship.