### PR TITLE
Derive the deb's manifest from the tarball's

### DIFF
--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -69,7 +69,7 @@ jobs:
       #
       # `--only` is the other half. 3.0.0 gives the child the keychain and
       # nothing else, so what the build consumes is named here rather than
-      # subtracted downstream: the deploy key, for `git-buildnumber.sh
+      # subtracted downstream: the deploy key, for `ship.sh buildnumber
       # generate`. APPLE_KEYCHAIN arrives on its own. This replaced a ten-line
       # `unset` denylist in ci-release.sh, which was fail-open — every
       # credential added to the secrets file reached xcodebuild until somebody
@@ -87,7 +87,7 @@ jobs:
 
       # No keychain: nothing here signs. The build number comes from the file
       # the build step wrote, because the two must publish the same one and
-      # only the first allocates — `git-buildnumber.sh generate` pushes a ref to
+      # only the first allocates — `ship.sh buildnumber generate` pushes a ref to
       # claim it, so calling it twice would upload an artifact whose
       # CFBundleVersion is not the one Apple was told about.
       - name: 'upload ${{ matrix.platform }}'

--- a/.github/workflows/make_deb.yaml
+++ b/.github/workflows/make_deb.yaml
@@ -25,18 +25,48 @@ jobs:
       - id: build
         run: |
           path=debian/opt/authpass
-          cd "$path"
-          wget https://authpass-data.codeux.design/data/artifacts/authpass-linux-latest.tar.gz
-          tar -zxvf authpass-linux-latest.tar.gz authpass -C . --strip-components=1
-          rm authpass-linux-latest.tar.gz
-          version=$(cat version.txt)
+          base=https://authpass-data.codeux.design/data/artifacts
+          # The sidecar first, then the artifact: the two uploads are not
+          # atomic, so fetching in this order turns a mid-publish skew into a
+          # digest mismatch — loud and retryable — rather than a manifest
+          # describing bytes we do not have. Tolerated when absent: the server
+          # only recently learned to accept manifests, and a tarball published
+          # before that has none.
+          wget "${base}/authpass-linux-latest.tar.gz.manifest.json" \
+            || echo "WARNING: no manifest beside the tarball — the deb will carry no provenance record"
+          wget "${base}/authpass-linux-latest.tar.gz"
+          src=authpass-linux-latest.tar.gz
+          if [ -f authpass-linux-latest.tar.gz.manifest.json ]; then
+            # Restore the versioned names the manifest records: a reader
+            # refuses a sidecar whose stem disagrees with its artifact field,
+            # and the parent digest check finds the artifact by that name.
+            src=$(jq -r .artifact authpass-linux-latest.tar.gz.manifest.json)
+            mv authpass-linux-latest.tar.gz.manifest.json "${src}.manifest.json"
+            mv authpass-linux-latest.tar.gz "${src}"
+          fi
+          tar -zxvf "${src}" -C "${path}" --strip-components=1 authpass
+          version=$(cat "${path}/version.txt")
           version_name=${version/+/_}
           filename="authpass-linux-${version_name}.deb"
-          cd ../../../
           sed -i "s/^Version=1.0/Version=${version}/g" debian/usr/share/applications/authpass.desktop
           sed -i "s/^Version: 1.0/Version: ${version}/g" debian/DEBIAN/control
-          dpkg-deb --build --root-owner-group ./debian 
+          dpkg-deb --build --root-owner-group ./debian
           mv debian.deb $filename
+          if [ -f "${src}.manifest.json" ]; then
+            # The deb inherits the tarball's build facts — gitSha, dirty,
+            # version, build number — and records its own packaging step:
+            # this checkout is the default branch at trigger time, derivable
+            # from nothing afterwards, and a broken Depends: line's
+            # provenance is this commit, not the tarball's. The tarball sits
+            # beside its manifest here, so the parent digest is verified in
+            # the same call. upload-artifact.sh then ships the deb's sidecar
+            # beside the deb on its own.
+            ./authpass/_tools/ship.sh manifest write \
+              --artifact "${filename}" --platform linux --format deb \
+              --derived-from "${src}.manifest.json" \
+              --packaging "gitSha=$(git rev-parse HEAD)" \
+              --packaging "dirty=false"
+          fi
           echo "::set-output name=outputfilename::${filename}"
           echo "::set-output name=outputpath::${filename}"
       - name: upload artifact

--- a/authpass/_tools/cux_ship/pubspec.lock
+++ b/authpass/_tools/cux_ship/pubspec.lock
@@ -77,8 +77,8 @@ packages:
     dependency: "direct main"
     description:
       path: cux_ship
-      ref: "84fe85eb2980d577e5bccf52f866806d6b7df10c"
-      resolved-ref: "84fe85eb2980d577e5bccf52f866806d6b7df10c"
+      ref: cc4190228d64d1d16ccf3e0330bd09ba351ce43a
+      resolved-ref: cc4190228d64d1d16ccf3e0330bd09ba351ce43a
       url: "https://github.com/codeuxdesign/cux_ship.git"
     source: git
     version: "3.4.0-dev.1"

--- a/authpass/_tools/cux_ship/pubspec.lock
+++ b/authpass/_tools/cux_ship/pubspec.lock
@@ -76,10 +76,11 @@ packages:
   cux_ship:
     dependency: "direct main"
     description:
-      name: cux_ship
-      sha256: "55ef4abc8a6e79e1c67130c5ede4ba44356784d63d59c8c44402d1f113ae1a4a"
-      url: "https://pub.dev"
-    source: hosted
+      path: cux_ship
+      ref: "6a8254e96df543e6c22e2edadfc443c70ab6c04c"
+      resolved-ref: "6a8254e96df543e6c22e2edadfc443c70ab6c04c"
+      url: "https://github.com/codeuxdesign/cux_ship.git"
+    source: git
     version: "3.4.0-dev.1"
   cux_ship_verify:
     dependency: transitive
@@ -193,6 +194,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.2"
+  pub_semver:
+    dependency: transitive
+    description:
+      name: pub_semver
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   source_span:
     dependency: transitive
     description:

--- a/authpass/_tools/cux_ship/pubspec.lock
+++ b/authpass/_tools/cux_ship/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      sha256: be169cf6ac481e052c4538715d88841d567150dfe1df38aaec76461a4e7b39f2
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.9"
+    version: "4.1.0"
   args:
     dependency: transitive
     description:
@@ -65,22 +65,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cux_buildnumber:
+    dependency: "direct main"
+    description:
+      name: cux_buildnumber
+      sha256: "6993d7c0759baf5675234cbe7ad22c3f1595c1ad92d1765fca84be5732921ff0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0-dev.1"
   cux_ship:
     dependency: "direct main"
     description:
       name: cux_ship
-      sha256: "81f6f27c7d2cbb73bd39239bf7b5e44a8df2a384d43cde9d02410e19a67ed1a6"
+      sha256: "55ef4abc8a6e79e1c67130c5ede4ba44356784d63d59c8c44402d1f113ae1a4a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.4.0-dev.1"
   cux_ship_verify:
     dependency: transitive
     description:
       name: cux_ship_verify
-      sha256: "6ba516d144d17cbbc42b488c767a8b54e819a4db027f758525b454d4bfb61f26"
+      sha256: a1d3b07e8e01c986c4da2b42234eeb00ef8fbe26570ee0b833802c244bee572a
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.0"
   dart_jsonwebtoken:
     dependency: transitive
     description:
@@ -149,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
+      sha256: "1976370a4df3091bb0f72409c187ad1f9132a818bc6b95ca59c0bae1c75c688e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.1"
+    version: "4.9.2"
   meta:
     dependency: transitive
     description:
@@ -169,14 +177,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  petitparser:
-    dependency: transitive
-    description:
-      name: petitparser
-      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.2"
   pointycastle:
     dependency: transitive
     description:
@@ -241,14 +241,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
-  xml:
-    dependency: transitive
-    description:
-      name: xml
-      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.1"
   yaml:
     dependency: transitive
     description:

--- a/authpass/_tools/cux_ship/pubspec.lock
+++ b/authpass/_tools/cux_ship/pubspec.lock
@@ -77,8 +77,8 @@ packages:
     dependency: "direct main"
     description:
       path: cux_ship
-      ref: "6a8254e96df543e6c22e2edadfc443c70ab6c04c"
-      resolved-ref: "6a8254e96df543e6c22e2edadfc443c70ab6c04c"
+      ref: "84fe85eb2980d577e5bccf52f866806d6b7df10c"
+      resolved-ref: "84fe85eb2980d577e5bccf52f866806d6b7df10c"
       url: "https://github.com/codeuxdesign/cux_ship.git"
     source: git
     version: "3.4.0-dev.1"

--- a/authpass/_tools/cux_ship/pubspec.yaml
+++ b/authpass/_tools/cux_ship/pubspec.yaml
@@ -18,7 +18,17 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  cux_ship: ^3.4.0-dev.1
+  # From git at a pinned commit, not pub: the manifest writer (`cux_ship
+  # manifest write`) is on main and unreleased, and Herbert wants both
+  # consuming projects on it before a version number is spent. A full sha,
+  # never a branch — a branch resolves to whatever it points at on the next
+  # `pub get`, so two machines would build different code from one pubspec.
+  # TO RETURN TO PUB: restore `cux_ship: ^x.y.z` once the writer is released.
+  cux_ship:
+    git:
+      url: https://github.com/codeuxdesign/cux_ship.git
+      path: cux_ship
+      ref: 6a8254e96df543e6c22e2edadfc443c70ab6c04c
   # The git-buildnumber port, invoked through ship.sh's `buildnumber`
   # dispatch. Replaces the shell script release.sh used to curl from the
   # mutable `stable` branch and execute — unpinned, unhashed, run on a CI

--- a/authpass/_tools/cux_ship/pubspec.yaml
+++ b/authpass/_tools/cux_ship/pubspec.yaml
@@ -28,7 +28,11 @@ dependencies:
     git:
       url: https://github.com/codeuxdesign/cux_ship.git
       path: cux_ship
-      ref: 6a8254e96df543e6c22e2edadfc443c70ab6c04c
+      # DO NOT MERGE at this ref: 84fe85e is cux_ship PR #11 (--derived-from),
+      # on a feature branch — a squash-merge would strand this sha, which is
+      # the exact decay BUILD-TAGS documents. Repin to the main sha once #11
+      # lands, before this PR merges.
+      ref: 84fe85eb2980d577e5bccf52f866806d6b7df10c
   # The git-buildnumber port, invoked through ship.sh's `buildnumber`
   # dispatch. Replaces the shell script release.sh used to curl from the
   # mutable `stable` branch and execute — unpinned, unhashed, run on a CI

--- a/authpass/_tools/cux_ship/pubspec.yaml
+++ b/authpass/_tools/cux_ship/pubspec.yaml
@@ -28,11 +28,9 @@ dependencies:
     git:
       url: https://github.com/codeuxdesign/cux_ship.git
       path: cux_ship
-      # DO NOT MERGE at this ref: 84fe85e is cux_ship PR #11 (--derived-from),
-      # on a feature branch — a squash-merge would strand this sha, which is
-      # the exact decay BUILD-TAGS documents. Repin to the main sha once #11
-      # lands, before this PR merges.
-      ref: 84fe85eb2980d577e5bccf52f866806d6b7df10c
+      # cux_ship main, carrying `manifest write --derived-from` (PR #11) and
+      # the aab/ipa baked-value cross-checks (PR #10).
+      ref: cc4190228d64d1d16ccf3e0330bd09ba351ce43a
   # The git-buildnumber port, invoked through ship.sh's `buildnumber`
   # dispatch. Replaces the shell script release.sh used to curl from the
   # mutable `stable` branch and execute — unpinned, unhashed, run on a CI

--- a/authpass/_tools/cux_ship/pubspec.yaml
+++ b/authpass/_tools/cux_ship/pubspec.yaml
@@ -18,4 +18,11 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  cux_ship: ^3.1.0
+  cux_ship: ^3.4.0-dev.1
+  # The git-buildnumber port, invoked through ship.sh's `buildnumber`
+  # dispatch. Replaces the shell script release.sh used to curl from the
+  # mutable `stable` branch and execute — unpinned, unhashed, run on a CI
+  # machine holding push credentials. A separate package from cux_ship (an
+  # allocator whose only dependency is git should not pull googleapis), but
+  # pinned by the same lockfile so there is exactly one place to bump.
+  cux_buildnumber: ^0.1.0-dev.1

--- a/authpass/_tools/release.sh
+++ b/authpass/_tools/release.sh
@@ -113,6 +113,37 @@ echo "::set-output name=appbuildnumber::$buildnumber"
 mkdir -p "$(dirname "${buildnumber_record}")"
 echo "${buildnumber}" > "${buildnumber_record}"
 
+# What every build manifest records, captured *before* any build step can move
+# the tree — the writer refuses to derive gitSha and dirty itself, because it
+# runs after the build, where a moved tree is invisible.
+manifest_version=$(grep version pubspec.yaml | head -1 | cut -d' ' -f2 | cut -d'+' -f1)
+manifest_gitsha=$(git rev-parse HEAD)
+if test -z "$(git status --porcelain)" ; then
+    manifest_dirty=--no-dirty
+else
+    manifest_dirty=--dirty
+fi
+flutter_version=$($FLT --version 2>/dev/null | head -1 | awk '{print $2}')
+
+# Writes <artifact>.manifest.json beside the artifact — schema 2, the digest
+# taken from the bytes as they stand, so it is called after signing and
+# packing, never before. The default sidecar name matters: the android matrix
+# puts six flavors' artifacts through here, and a fixed manifest.json could
+# only describe one of them.
+write_manifest() {
+    local artifact="$1" platform="$2" format="$3" flavor="${4:-}"
+    ./_tools/ship.sh manifest write \
+        --artifact "${artifact}" \
+        --platform "${platform}" \
+        --format "${format}" \
+        ${flavor:+--flavor "${flavor}"} \
+        --version-name "${manifest_version}" \
+        --build-number "${buildnumber}" \
+        --git-sha "${manifest_gitsha}" \
+        "${manifest_dirty}" \
+        --toolchain "flutter=${flutter_version}"
+}
+
 $FLT pub get
 case "${flavor}" in
     ios)
@@ -130,6 +161,7 @@ case "${flavor}" in
         # decrypts. See docs/apple-signing.md.
         if does_phase build ; then
             ./_tools/build-ios.sh -t lib/env/production.dart -b $buildnumber
+            write_manifest build/ios/ipa/authpass.ipa ios ipa
         fi
         if does_phase upload ; then
             ./_tools/ship.sh secrets exec --keystore upload --api-key upload \
@@ -141,6 +173,9 @@ case "${flavor}" in
         # and asks for one.
         if does_phase build ; then
             ./_tools/build-macos.sh -t lib/env/production.dart -b $buildnumber
+            # The export names the .pkg after the scheme, so glob like
+            # upload-macos.sh does.
+            write_manifest "$(ls build/macos/pkg/*.pkg | head -1)" macos pkg
         fi
         if does_phase upload ; then
             ./_tools/ship.sh secrets exec --keystore upload --api-key upload \
@@ -156,11 +191,13 @@ case "${flavor}" in
         outputpath="${apkpath}/${outputfilename}"
         echo "Copying to output apk ${apk}"
         cp ${apk} ${outputpath}
+        write_manifest "${outputpath}" android apk "${flavor}"
         echo "::set-output name=outputfilename::${outputfilename}"
         echo "::set-output name=outputpath::${outputpath}"
     ;;
     playstoredev)
         $FLT build -v appbundle -t lib/env/production.dart --release --build-number $buildnumber --flavor playstoredev
+        write_manifest build/app/outputs/bundle/playstoredevRelease/app-playstoredev-release.aab android aab playstoredev
         echo "Check if we are in a beta branch ${GITHUB_REF}"
         track=internal
         if [[ "${GITHUB_REF:-}" == *"beta"* || "${GITHUB_REF:-}" == *"stable"* ]] ; then
@@ -178,6 +215,7 @@ case "${flavor}" in
     ;;
     android | playstore)
         $FLT build -v appbundle -t lib/env/production.dart --release --build-number $buildnumber --flavor playstore
+        write_manifest build/app/outputs/bundle/playstoreRelease/app-playstore-release.aab android aab playstore
         ./_tools/upload-android.sh -f playstore -t internal -b $buildnumber
     ;;
     linux)
@@ -190,6 +228,9 @@ case "${flavor}" in
         echo "${version}+${buildnumber}" > build/${flavor}/${arch}/release/version.txt
         echo "${version}+${buildnumber}" > build/${flavor}/${arch}/release/bundle/version.txt
         tar czvf ${outputpath} --transform "s/^build.*bundle/authpass/" build/${flavor}/x64/release/bundle
+        # The tarball is the parent of the derived .deb: make_deb downloads the
+        # sidecar next to it, verifies the bytes, and derives its own manifest.
+        write_manifest "${outputpath}" linux tar.gz
         echo "::set-output name=appversion::${version}"
         echo "::set-output name=outputfilename::${outputfilename}"
         echo "::set-output name=outputpath::${outputpath}"
@@ -204,6 +245,9 @@ case "${flavor}" in
 
         outputfilename="AuthPass-setup-${version}_${buildnumber}.exe"
         outputpath="build/_authpass/windows/setup/${outputfilename}"
+        # `exe` has no cross-check reader in cux_ship; the manifest is taken on
+        # trust, which the writer says out loud.
+        write_manifest "${outputpath}" windows exe
         #echo "${version}+${buildnumber}" > build/${flavor}/release/version.txt
         #echo "${version}+${buildnumber}" > build/${flavor}/release/bundle/version.txt
         #tar czvf ${outputpath} --transform "s/^build.*bundle/authpass/" build/${flavor}/release/bundle
@@ -224,6 +268,7 @@ case "${flavor}" in
 
         version="${version}" buildnumber="${buildnumber}" \
           _tools/windows/create_portable.sh
+        write_manifest "build/_authpass/windows/release/AuthPass-portable-${version}_${buildnumber}.zip" windows zip
     ;;
     msix)
         version=$(cat pubspec.yaml | grep version | cut -d' ' -f2 | cut -d'+' -f1)
@@ -240,6 +285,7 @@ case "${flavor}" in
         outputfilename="authpass-${version}_${buildnumber}.msix"
         outputpath="${outputdir}/${outputfilename}"
         cp "${outputdir}/authpass.msix" "${outputpath}"
+        write_manifest "${outputpath}" windows msix
 
         #echo "${version}+${buildnumber}" > build/${flavor}/release/version.txt
         #echo "${version}+${buildnumber}" > build/${flavor}/release/bundle/version.txt
@@ -249,6 +295,9 @@ case "${flavor}" in
         echo "::set-output name=outputpath::${outputpath}"
     ;;
     web)
+        # No manifest, deliberately: web deploys a directory to gh-pages, no
+        # archive exists in the flow, and a required digest of a directory is
+        # not a thing. If web ever ships as an archive, it gets one then.
         version=$(cat pubspec.yaml | grep version | cut -d' ' -f2 | cut -d'+' -f1)
         $FLT build web -t lib/env/web.dart --release \
             --dart-define=AUTHPASS_VERSION=$version \

--- a/authpass/_tools/release.sh
+++ b/authpass/_tools/release.sh
@@ -31,22 +31,6 @@ ls ${DEPS}/flutter || echo "Flutter not found"
 
 $FLT --version
 
-if ! test -e ./git-buildnumber.sh ; then
-    # --fail matters more than it looks. Without it curl writes the *error body*
-    # to the file, and the next two lines chmod +x it and run it — so a bad day
-    # at raw.githubusercontent.com becomes an executable HTML page. That is not
-    # hypothetical: on 2026-08-17 a 429 during a GitHub outage produced
-    #
-    #     ./git-buildnumber.sh: line 1: 429:: command not found
-    #
-    # and the build number came back empty. --retry covers the transient
-    # statuses (408, 429, 5xx) so the outage is survived rather than merely
-    # reported, and -S keeps the reason visible when it is not.
-    curl -sS --fail --retry 5 --retry-delay 5 \
-        -O https://raw.githubusercontent.com/hpoul/git-buildnumber/stable/git-buildnumber.sh
-    chmod +x git-buildnumber.sh
-fi
-
 # Which half of a release this run does. `all` — the default, and what every
 # platform but ios and macos ever uses — is the behaviour this script has always
 # had. The Apple path splits it into two CI steps, for two reasons:
@@ -67,7 +51,7 @@ esac
 does_phase() { test "${RELEASE_PHASE}" = all -o "${RELEASE_PHASE}" = "$1" ; }
 
 # The two steps must publish the *same* build number, and only the first one
-# allocates. `git-buildnumber.sh generate` pushes a ref to claim it, so calling
+# allocates. `ship.sh buildnumber generate` pushes a ref to claim it, so calling
 # it twice would claim two and upload an artifact whose CFBundleVersion is not
 # the one Apple was told about.
 #
@@ -113,7 +97,14 @@ if test -z "$buildnumber" ; then
       git checkout -- pubspec.lock
       ;;
     esac
-    buildnumber=`./git-buildnumber.sh generate`
+    # The Dart port of git-buildnumber, resolved by _tools/cux_ship's lockfile
+    # like the rest of the release tooling. Replaces a shell script this used
+    # to curl from a mutable branch and execute — unpinned, on a runner
+    # holding push credentials, and one GitHub 429 away from executing an
+    # error page (see the git history of this block). Same command surface:
+    # the number on stdout, logs on stderr, GIT_PUSH_REMOTE and
+    # GIT_SSH_COMMAND honored from the environment.
+    buildnumber=$(./_tools/ship.sh buildnumber generate)
 else
 	echo "WARNING: forcing buildnumber $buildnumber"
 fi

--- a/authpass/_tools/ship.sh
+++ b/authpass/_tools/ship.sh
@@ -36,4 +36,15 @@ if [ ! -f .dart_tool/package_config.json ]; then
   "$dart" pub get >&2
 fi
 
+# The build number allocator. A separate package from cux_ship, resolved by the
+# same lockfile here so there is exactly one pin. Replaces the
+# git-buildnumber.sh release.sh used to curl from a mutable branch and execute.
+# Runs from this directory, which is inside the repository; git does not care
+# where inside, and `generate` prints the number on stdout and everything else
+# on stderr, same as the script it replaces.
+if [ "${1:-}" = "buildnumber" ]; then
+  shift
+  exec "$dart" run cux_buildnumber:git_buildnumber "$@"
+fi
+
 exec "$dart" run cux_ship "$@"

--- a/authpass/_tools/upload-artifact.sh
+++ b/authpass/_tools/upload-artifact.sh
@@ -47,3 +47,20 @@ curl --request POST \
     --form upload="@${upload_file}" \
     --form filename="${remote_name}" | cat
 
+# The build manifest travels beside its artifact, across this hop like every
+# other: a repackager (make_deb) downloads it next to the tarball, verifies
+# the bytes against its digest, and derives its own manifest from it. Absent
+# for artifacts nothing writes one for yet, so its absence is not an error —
+# but the two uploads are not atomic, so a `latest` alias can briefly name a
+# tarball whose sidecar is one PUT behind; the consumer's digest check turns
+# that skew into a loud retry rather than silent wrongness.
+manifest_file="${upload_file}.manifest.json"
+if [ -f "${manifest_file}" ]; then
+  curl --request POST \
+      --url https://data.authpass.app/data/artifact.push \
+      --fail \
+      --form token="${token}" \
+      --form upload="@${manifest_file}" \
+      --form filename="${remote_name}.manifest.json" | cat
+fi
+

--- a/authpass/_tools/upload-artifact.sh
+++ b/authpass/_tools/upload-artifact.sh
@@ -54,6 +54,11 @@ curl --request POST \
 # but the two uploads are not atomic, so a `latest` alias can briefly name a
 # tarball whose sidecar is one PUT behind; the consumer's digest check turns
 # that skew into a loud retry rather than silent wrongness.
+# Tolerated failure, for now: artifact-push.php admits filenames from an
+# anchored allow-list, and no `*.manifest.json` companion pattern is in it yet
+# — so until the server learns them, this refusal is expected and must not
+# fail an artifact upload that already succeeded. Drop the `||` once the
+# allow-list knows manifests; a silent-refusal state is not worth keeping.
 manifest_file="${upload_file}.manifest.json"
 if [ -f "${manifest_file}" ]; then
   curl --request POST \
@@ -61,6 +66,7 @@ if [ -f "${manifest_file}" ]; then
       --fail \
       --form token="${token}" \
       --form upload="@${manifest_file}" \
-      --form filename="${remote_name}.manifest.json" | cat
+      --form filename="${remote_name}.manifest.json" | cat \
+    || echo "WARNING: manifest upload refused — add ${remote_name}.manifest.json's pattern to artifact-push.php's allow-list" >&2
 fi
 


### PR DESCRIPTION
The deb repackaging (make_deb.yaml) now downloads the sidecar beside the tarball, restores the versioned names the manifest records (a reader refuses a stem/artifact-field mismatch), and writes the deb's own schema-2 manifest with `--derived-from`: build facts hoisted from the tarball, the derivation chain assembled by the tool with the parent digest verified in the same call, and a `packaging` record naming this checkout's commit — which is the default branch at trigger time, derivable from nothing afterwards (the OPEN settled in cux_ship's build-manifest.md).

Sidecar-first download order turns a mid-publish skew of the `latest` alias into a loud retryable digest mismatch. Absence is tolerated with a warning, since tarballs published before the server learned manifests have none.

**One gate before merge** (the pin gate is closed: cux_ship#11 is true-merged and this PR now pins main sha cc41902):
