### PR TITLE
Record every upload with an uploaded/ tag

### DIFF
--- a/.cux-ship.yaml
+++ b/.cux-ship.yaml
@@ -6,3 +6,12 @@
 # CHANGELOG.md and store/ deliberately stay at this level: a release describes
 # what the repository shipped, not what one package did.
 app-dir: authpass
+
+# Every upload that succeeds writes an annotated `uploaded/v{version}+{build}`
+# tag at the commit the artifact was built from (fed by the manifest beside
+# it), pushed before the store is contacted — so nothing ships unprovable.
+# One tag per commit, first store wins. The namespace is deliberately clear of
+# both `v*` (workflow triggers) and `fdroid-v*` (F-Droid's builder).
+tag:
+  upload:
+    enabled: true

--- a/authpass/_tools/cux_ship/pubspec.lock
+++ b/authpass/_tools/cux_ship/pubspec.lock
@@ -77,8 +77,8 @@ packages:
     dependency: "direct main"
     description:
       path: cux_ship
-      ref: "176924c4ee5bcda9155a44f633a10d24ea41f9dc"
-      resolved-ref: "176924c4ee5bcda9155a44f633a10d24ea41f9dc"
+      ref: "1b6d069a6cc242877c47f39dae37eb1e555b2f32"
+      resolved-ref: "1b6d069a6cc242877c47f39dae37eb1e555b2f32"
       url: "https://github.com/codeuxdesign/cux_ship.git"
     source: git
     version: "3.4.1"

--- a/authpass/_tools/cux_ship/pubspec.lock
+++ b/authpass/_tools/cux_ship/pubspec.lock
@@ -76,11 +76,10 @@ packages:
   cux_ship:
     dependency: "direct main"
     description:
-      path: cux_ship
-      ref: "1b6d069a6cc242877c47f39dae37eb1e555b2f32"
-      resolved-ref: "1b6d069a6cc242877c47f39dae37eb1e555b2f32"
-      url: "https://github.com/codeuxdesign/cux_ship.git"
-    source: git
+      name: cux_ship
+      sha256: "802b7f419a5591993f4f5a6339872f016ffb69289817be2c3dd7c24cc6a6ffa7"
+      url: "https://pub.dev"
+    source: hosted
     version: "3.4.1"
   cux_ship_verify:
     dependency: transitive

--- a/authpass/_tools/cux_ship/pubspec.lock
+++ b/authpass/_tools/cux_ship/pubspec.lock
@@ -69,19 +69,19 @@ packages:
     dependency: "direct main"
     description:
       name: cux_buildnumber
-      sha256: "6993d7c0759baf5675234cbe7ad22c3f1595c1ad92d1765fca84be5732921ff0"
+      sha256: f46f5c962932bee2153205163300951519e2a571db753e82240a9a5674211d42
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0-dev.1"
+    version: "0.1.0"
   cux_ship:
     dependency: "direct main"
     description:
       path: cux_ship
-      ref: cc4190228d64d1d16ccf3e0330bd09ba351ce43a
-      resolved-ref: cc4190228d64d1d16ccf3e0330bd09ba351ce43a
+      ref: "176924c4ee5bcda9155a44f633a10d24ea41f9dc"
+      resolved-ref: "176924c4ee5bcda9155a44f633a10d24ea41f9dc"
       url: "https://github.com/codeuxdesign/cux_ship.git"
     source: git
-    version: "3.4.0-dev.1"
+    version: "3.4.1"
   cux_ship_verify:
     dependency: transitive
     description:

--- a/authpass/_tools/cux_ship/pubspec.yaml
+++ b/authpass/_tools/cux_ship/pubspec.yaml
@@ -34,7 +34,10 @@ dependencies:
       # cross-check reader and uploadCollisionExit = 3. The branch will be
       # true-merged, so this sha stays reachable; repin to the main sha once
       # #13 lands.
-      ref: 176924c4ee5bcda9155a44f633a10d24ea41f9dc
+      # 1b6d069 additionally runs the baked-value cross-check at `manifest
+      # write` time, refusing before the file exists — a wrong manifest on
+      # disk is a wrong manifest somebody will believe.
+      ref: 1b6d069a6cc242877c47f39dae37eb1e555b2f32
   # The git-buildnumber port, invoked through ship.sh's `buildnumber`
   # dispatch. Replaces the shell script release.sh used to curl from the
   # mutable `stable` branch and execute — unpinned, unhashed, run on a CI

--- a/authpass/_tools/cux_ship/pubspec.yaml
+++ b/authpass/_tools/cux_ship/pubspec.yaml
@@ -18,26 +18,11 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  # From git at a pinned commit, not pub: the manifest writer (`cux_ship
-  # manifest write`) is on main and unreleased, and Herbert wants both
-  # consuming projects on it before a version number is spent. A full sha,
-  # never a branch — a branch resolves to whatever it points at on the next
-  # `pub get`, so two machines would build different code from one pubspec.
-  # TO RETURN TO PUB: restore `cux_ship: ^x.y.z` once the writer is released.
-  cux_ship:
-    git:
-      url: https://github.com/codeuxdesign/cux_ship.git
-      path: cux_ship
-      # cux_ship PR #13 (`fix/record-upload-capability-check`): upload tagging
-      # that actually fires for --manifest callers — the guard on main at
-      # cc41902 skipped recording for exactly those — plus the .apk
-      # cross-check reader and uploadCollisionExit = 3. The branch will be
-      # true-merged, so this sha stays reachable; repin to the main sha once
-      # #13 lands.
-      # 1b6d069 additionally runs the baked-value cross-check at `manifest
-      # write` time, refusing before the file exists — a wrong manifest on
-      # disk is a wrong manifest somebody will believe.
-      ref: 1b6d069a6cc242877c47f39dae37eb1e555b2f32
+  # 3.4.1: the manifest writer with write-time cross-checks, --derived-from,
+  # upload tagging whose recording actually fires for --manifest callers (the
+  # 3.4.0 guard was silently dead for exactly those), the .apk cross-check
+  # reader, and uploadCollisionExit = 3.
+  cux_ship: ^3.4.1
   # The git-buildnumber port, invoked through ship.sh's `buildnumber`
   # dispatch. Replaces the shell script release.sh used to curl from the
   # mutable `stable` branch and execute — unpinned, unhashed, run on a CI

--- a/authpass/_tools/cux_ship/pubspec.yaml
+++ b/authpass/_tools/cux_ship/pubspec.yaml
@@ -28,9 +28,13 @@ dependencies:
     git:
       url: https://github.com/codeuxdesign/cux_ship.git
       path: cux_ship
-      # cux_ship main, carrying `manifest write --derived-from` (PR #11) and
-      # the aab/ipa baked-value cross-checks (PR #10).
-      ref: cc4190228d64d1d16ccf3e0330bd09ba351ce43a
+      # cux_ship PR #13 (`fix/record-upload-capability-check`): upload tagging
+      # that actually fires for --manifest callers — the guard on main at
+      # cc41902 skipped recording for exactly those — plus the .apk
+      # cross-check reader and uploadCollisionExit = 3. The branch will be
+      # true-merged, so this sha stays reachable; repin to the main sha once
+      # #13 lands.
+      ref: 176924c4ee5bcda9155a44f633a10d24ea41f9dc
   # The git-buildnumber port, invoked through ship.sh's `buildnumber`
   # dispatch. Replaces the shell script release.sh used to curl from the
   # mutable `stable` branch and execute — unpinned, unhashed, run on a CI

--- a/authpass/_tools/release.sh
+++ b/authpass/_tools/release.sh
@@ -204,11 +204,19 @@ case "${flavor}" in
           track=beta
         fi
         echo "Pushing to ${track}"
-        # Deliberately not fatal: re-running a release for a buildnumber Play
-        # already holds fails, and that is a no-op rather than a broken build.
+        # Deliberately not fatal — with one exception. Re-running a release for
+        # a buildnumber Play already holds fails, and that is a no-op rather
+        # than a broken build. But exit 3 is cux_ship's uploadCollisionExit:
+        # one build number has been used for two commits, and tolerating that
+        # would leave the provenance record naming the wrong one. The two used
+        # to be indistinguishable here, which is why the distinct code exists.
         exitCode=success
         ./_tools/upload-android.sh -f playstoredev -t "${track}" -b $buildnumber || exitCode=$?
 
+        if [[ "${exitCode}" == "3" ]] ; then
+          echo "upload refused: build number ${buildnumber} already names a different commit" >&2
+          exit 3
+        fi
         if [[ "${exitCode}" != "success" ]] ; then
           echo "upload failed. maybe this buildnumber was uploaded before? exitCode:$exitCode"
         fi

--- a/authpass/_tools/upload-android.sh
+++ b/authpass/_tools/upload-android.sh
@@ -111,8 +111,19 @@ echo "    version      $VERSION${BUILD_NUMBER:+ ($BUILD_NUMBER)}"
 # than publishing something mislabelled.
 cd _tools/cux_ship
 # not exec: the trap above still has an empty notes file to clean up
+# The manifest supplies the built commit for the `uploaded/` tag — recording
+# is manifest-fed, and with tag.upload.enabled an upload with neither manifest
+# nor --commit is *refused* by cux_ship, with a message naming the fix. So the
+# conditional only decides who explains the absence, not whether it is fatal:
+# a local build without a manifest passes --commit by hand or does not upload.
+MANIFEST=()
+# ../../ in the test too: this runs after the cd above.
+if [ -f "../../$AAB.manifest.json" ]; then
+  MANIFEST=(--manifest "../../$AAB.manifest.json")
+fi
 dart run cux_ship --yes play upload \
   --aab "../../$AAB" \
+  ${MANIFEST+"${MANIFEST[@]}"} \
   --package "$PACKAGE" \
   --track "$TRACK" \
   --version-name "$VERSION" \

--- a/authpass/_tools/upload-ios.sh
+++ b/authpass/_tools/upload-ios.sh
@@ -117,8 +117,17 @@ echo "    credential   $APPLE_API_KEY_ID, scoped to this app"
 # no --yes" as a refusal rather than an assumed yes.
 # not exec: the trap above still has a temp file to clean up
 cd _tools/cux_ship
+# The manifest supplies the built commit for the `uploaded/` tag. With
+# tag.upload.enabled, an upload with neither manifest nor --commit is refused
+# by cux_ship with a message naming the fix — see upload-android.sh.
+MANIFEST=()
+# ../../ in the test too: this runs after the cd above.
+if [ -f "../../$IPA.manifest.json" ]; then
+  MANIFEST=(--manifest "../../$IPA.manifest.json")
+fi
 dart run cux_ship --yes appstore upload \
   --artifact "../../$IPA" \
+  ${MANIFEST+"${MANIFEST[@]}"} \
   --bundle-id "$BUNDLE_ID" \
   --version-name "$VERSION" \
   --build-number "$BUILD_NUMBER" \

--- a/authpass/_tools/upload-macos.sh
+++ b/authpass/_tools/upload-macos.sh
@@ -101,9 +101,17 @@ echo "    credential   $APPLE_API_KEY_ID, scoped to this app"
 # --yes: see upload-ios.sh.
 # not exec: the trap above still has a temp file to clean up
 cd _tools/cux_ship
+# The manifest supplies the built commit for the `uploaded/` tag; see
+# upload-ios.sh.
+MANIFEST=()
+# ../../ in the test too: this runs after the cd above.
+if [ -f "../../$PKG.manifest.json" ]; then
+  MANIFEST=(--manifest "../../$PKG.manifest.json")
+fi
 dart run cux_ship --yes appstore upload \
   --platform macos \
   --artifact "../../$PKG" \
+  ${MANIFEST+"${MANIFEST[@]}"} \
   --bundle-id "$BUNDLE_ID" \
   --version-name "$VERSION" \
   --build-number "$BUILD_NUMBER" \


### PR DESCRIPTION
Switches on cux_ship's upload tagging (`tag.upload.enabled`): every store upload writes an annotated `uploaded/v{version}+{build}` tag at the manifest's built commit, pushed before the store is contacted — one tag per commit, first store wins, and the namespace is clear of both `v*` (workflow triggers) and `fdroid-v*` (F-Droid's builder).

The three upload scripts feed the sidecar manifest to the upload (`--manifest`), which supplies the commit; with tagging enabled a manifest-less, commit-less upload is refused by cux_ship with a message naming the fix. And release.sh's Play tolerance finally distinguishes what it could not before: **exit 3** (`uploadCollisionExit` — one build number on two commits) aborts the release, while an ordinary re-upload of a versionCode Play already holds stays a tolerated no-op. That distinction was the reason the exit code exists.

Validated locally at the pinned sha against production artifacts: the new `.apk` cross-check reader parsed three real flavors off data.authpass.app (sideload@2160, amazon@2096, huawei@2096, all 1.9.12) and refused garbage manifests naming both values and the source; the `tag.upload.enabled` guard refuses a commit-less upload with the right message; the dry-run path never contacted Play.

**Draft, one gate**: the pin is cux_ship PR codeuxdesign/cux_ship#13's branch sha (`176924c` — the fix for recording being silently dead for --manifest callers since 3.3.0; `cc41902` looks like it works and does not). #13 will be true-merged, so the pin stays resolvable; repin to the main sha when it lands, then un-draft.